### PR TITLE
Fix/foundry v9.245

### DIFF
--- a/module/lib.js
+++ b/module/lib.js
@@ -38,6 +38,7 @@ export class debug {
             canvas.sight.refresh();
         } else {
             CONFIG.Canvas.unexploredColor = PIXI.utils.rgb2hex([1 - unexploredDarkness, 1 - unexploredDarkness, 1 - unexploredDarkness]);
+            canvas.sight.updateFogExplorationColors()
             canvas.perception.schedule({sight: {refresh: true}});
         }
     }

--- a/module/settings.js
+++ b/module/settings.js
@@ -74,6 +74,7 @@ export const registerSettings = function () {
         config: true,
         onChange: value => {
             CONFIG.Canvas.exploredColor = PIXI.utils.rgb2hex([1 - value, 1 - value, 1 - value]);
+            canvas.sight.updateFogExplorationColors()
         }
     });
     game.settings.register("lessfog", "unexplored_darkness", {

--- a/module/settings.js
+++ b/module/settings.js
@@ -74,7 +74,9 @@ export const registerSettings = function () {
         config: true,
         onChange: value => {
             CONFIG.Canvas.exploredColor = PIXI.utils.rgb2hex([1 - value, 1 - value, 1 - value]);
-            canvas.sight.updateFogExplorationColors()
+            if (isNewerVersion(game.version || game.data.version, '0.8.2')) {
+                canvas.sight.updateFogExplorationColors()
+            }
         }
     });
     game.settings.register("lessfog", "unexplored_darkness", {


### PR DESCRIPTION
# Description
This change updates fog colors for explored and unexplored areas after a user modifies their module settings.  Attempting to maintain similar version safety between unexplored and explored.

## Issues Closed
Closes #22 